### PR TITLE
Add app name to notifications

### DIFF
--- a/devify
+++ b/devify
@@ -11,9 +11,9 @@ export DBUS_SESSION_BUS_ADDRESS
 
 notify() {
   if [ "$status" == "add" ]; then
-    su "$user" -c "notify-send -u low -i ${icon_pack}/$2.svg '$1' 'Connected'"
+    su "$user" -c "notify-send -u low -i ${icon_pack}/$2.svg -a Devify '$1' 'Connected'"
   else
-    su "$user" -c "notify-send -u low -i ${icon_pack}/$2.svg '$1' 'Disconnected'"
+    su "$user" -c "notify-send -u low -i ${icon_pack}/$2.svg -a Devify '$1' 'Disconnected'"
   fi
 }
 


### PR DESCRIPTION
* `notify-send` has a `-a` option to specify the app name. This is now set to `Devify`

Screenshot with previous version:
![image](https://github.com/pog102/devify/assets/488489/4dd5c2c4-5520-429d-8fab-88be51a26303)

Screenshot with this pull request:
![image](https://github.com/pog102/devify/assets/488489/b1cd52a5-51a7-4f21-9c36-d6d456ed6cb1)
