### PR TITLE
Logitech MX Master 3 connection

### DIFF
--- a/devify
+++ b/devify
@@ -45,7 +45,7 @@ case "$1" in
 *"Keyboard"*)
   notify "$1" "generic_keyboard"
   ;;
-*"Mouse"* | *"Logitech MX"*)
+*"Mouse"* | *"Logitech MX"* | *"MX Master"*)
   notify "$1" "generic_mouse"
   ;;
 *"X-Box"* | *"Xbox"*)


### PR DESCRIPTION
* The Logitech MX Master 3 identifies itself as `MX Master 3` when connected. It is now well managed in the `devify` script.

screenshot of connection/deconnection (we can see that the name is different when connecting or disconnecting):
![image](https://github.com/pog102/devify/assets/488489/034c9de5-e9f3-4c27-b4ed-7a81927829d6)
