### PR TITLE
Allow custom icons for unkown device types

### DIFF
--- a/devify
+++ b/devify
@@ -123,6 +123,7 @@ case "$device_name" in
     notify "$device_name" "network_adapter"
     ;;
   *)
-    notify "$device_name" ""
+    safe_name=$(echo "$device_name" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]_-')
+    notify "$device_name" "custom_$safe_name"
   ;;
 esac


### PR DESCRIPTION
Usually, when an device that doesn't fit into the predefined cases, the notification service is called with an empty string in the second argument. With this change, instead a sanitized version of the device name prefixed with "custom_" will be sent, allowing users to add a cosponsoring icon to the `/usr/share/icons/Monodev/` directory, allowing for custom icons for these unknown devices.